### PR TITLE
better timing by making file copies

### DIFF
--- a/GOES/GOES-17/GLM/Makefile.am
+++ b/GOES/GOES-17/GLM/Makefile.am
@@ -19,7 +19,7 @@ glm_read_SOURCES = glm_read.c un_test.h tst_utils.c
 TESTS = tst_glm.sh 
 
 # Make sure this file is included in distribution.
-EXTRA_DIST = tst_glm.sh clearcache.sh
+EXTRA_DIST = tst_glm.sh
 
 # Clean data files for distclean target.
 DISTCLEANFILES = *.nc

--- a/GOES/GOES-17/GLM/clearcache.sh
+++ b/GOES/GOES-17/GLM/clearcache.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Note, we are using "echo 3", but it is not recommended in production instead use "echo 1"
-sync
-echo 3 > /proc/sys/vm/drop_caches

--- a/GOES/GOES-17/GLM/glm_read.c
+++ b/GOES/GOES-17/GLM/glm_read.c
@@ -159,7 +159,6 @@ main(int argc, char **argv)
 	    base_name[len] = 0;
 	    sprintf(new_file, "%s_%d.nc", base_name, t);
 	    sprintf(cmd, "cp %s %s", GLM_DATA_FILE, new_file);
-	    /* system("./clearcache.sh"); */
 	    system(cmd);
 	}
 	else

--- a/GOES/GOES-17/GLM/glm_read.c
+++ b/GOES/GOES-17/GLM/glm_read.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 #include <time.h>
 #include <sys/time.h> /* Extra high precision time info. */
 #include <math.h>
@@ -123,6 +124,7 @@ main(int argc, char **argv)
     int meta_read_us = 0, meta_max_read_us = 0, meta_min_read_us = NC_MAX_INT;
     int meta_tot_read_us = 0, meta_avg_read_us;
     int num_trials = 1;
+    char new_file[1024];
     int t;
     
     while ((c = getopt(argc, argv, "vt")) != EOF)
@@ -147,14 +149,28 @@ main(int argc, char **argv)
     {
 	/* Clear all buffers. */
 	if (timing)
-	    system("./clearcache.sh");
+	{
+	    char cmd[1024];
+	    char base_name[1024];
+	    size_t len;
 
+	    len = strlen(GLM_DATA_FILE) - 3;
+	    strncpy(base_name, GLM_DATA_FILE, len);
+	    base_name[len] = 0;
+	    sprintf(new_file, "%s_%d.nc", base_name, t);
+	    sprintf(cmd, "cp %s %s", GLM_DATA_FILE, new_file);
+	    /* system("./clearcache.sh"); */
+	    system(cmd);
+	}
+	else
+	    strcpy(new_file, GLM_DATA_FILE);
+	
 	/* Start timer. */
 	if (gettimeofday(&start_time, NULL))
 	    ERR;
 
 	/* Read file. */
-	if (glm_read_file(GLM_DATA_FILE, verbose))
+	if (glm_read_file(new_file, verbose))
 	    ERR;
 
 	/* Handle timing. */
@@ -166,6 +182,16 @@ main(int argc, char **argv)
 	if (meta_read_us < meta_min_read_us)
 	    meta_min_read_us = meta_read_us;
 	meta_tot_read_us += meta_read_us;
+
+	if (timing)
+	{
+	    char cmd[1024];
+	    sprintf(cmd, "rm %s", new_file);
+	    system(cmd);
+	}
+	
+	/* if (verbose) */
+	    printf("meta_read_us %d\n", meta_read_us);
     }
 
     if (timing)


### PR DESCRIPTION
Part of #2.

I had been using clearcache.sh to clear the caches, but it gave very inconsistent results. I have switcheed to making a copy of the input file for each test run. This is defeating bufferin and giving consistent results.